### PR TITLE
Add inbox, calendar and search pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,46 @@
+import bodyParser from 'body-parser';
+import cors from 'cors';
+import express from 'express';
+import mysql from 'mysql';
+
+const app = express();
+const port = 3008;
+
+app.use(bodyParser.json());
+app.use(cors());
+
+const db = mysql.createConnection({
+    host: 'localhost',
+    user: 'info',
+    password: 'w5FJerncrnSS6XDL', // Replace with your MySQL password
+    database: 'info'
+});
+
+db.connect((err) => {
+    if (err) throw err;
+    console.log('Connected to MySQL database.');
+});
+
+app.post('/search', (req, res) => {
+    const { userId, name, classValue, gender } = req.body;
+    let query = 'SELECT i.*, ui.image FROM info i LEFT JOIN user_images ui ON i.user_id = ui.user_id WHERE 1=1';
+
+    if (userId) query += ` AND i.user_id = ${mysql.escape(userId)}`;
+    if (name) query += ` AND i.name LIKE ${mysql.escape('%' + name + '%')}`;
+    if (classValue) query += ` AND i.class = ${mysql.escape(classValue)}`;
+    if (gender) query += ` AND i.gender = ${mysql.escape(gender)}`;
+
+    db.query(query, (err, results) => {
+        if (err) throw err;
+        results.forEach(user => {
+            if (user.image) {
+                user.image = user.image.toString('base64');
+            }
+        });
+        res.json(results);
+    });
+});
+
+app.listen(port, () => {
+    console.log(`Server running at http://localhost:${port}/`);
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,9 @@ import UserDashboard from './pages/UserDashboard';
 import ActivityDashboard from './pages/ActivityDashboard';
 import TeamDashboard from './pages/TeamDashboard';
 import EditActivity from './pages/EditActivity';
+import CalendarPage from './pages/CalendarPage';
+import Inbox from './pages/Inbox';
+import SearchPage from './pages/SearchPage';
 
 function App() {
   const location = useLocation();
@@ -97,6 +100,9 @@ function App() {
         <Route path="/activity" element={<ActivityDashboard />} />
         <Route path="/team" element={<TeamDashboard />} />
         <Route path="/edit" element={<EditActivity />} />
+        <Route path="/calendar" element={<CalendarPage />} />
+        <Route path="/inbox" element={<Inbox />} />
+        <Route path="/search" element={<SearchPage />} />
       </Routes>
     </>
   );

--- a/src/pages/Inbox.jsx
+++ b/src/pages/Inbox.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import Header from '../partials/Header';
+import Sidebar from '../partials/Sidebar';
+
+function Inbox() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const messages = [
+    { id: 1, title: 'Welcome', content: 'This is your inbox.' },
+    { id: 2, title: 'Update', content: 'New features added.' },
+  ];
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <div className="relative flex flex-col flex-1 overflow-y-auto">
+        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+        <main className="p-6 space-y-4">
+          <h1 className="text-2xl font-bold">Inbox</h1>
+          <ul className="space-y-2">
+            {messages.map((m) => (
+              <li key={m.id} className="p-4 bg-white dark:bg-gray-800 rounded shadow">
+                <h2 className="font-semibold">{m.title}</h2>
+                <p>{m.content}</p>
+              </li>
+            ))}
+          </ul>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export default Inbox;

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import axios from 'axios';
+import Header from '../partials/Header';
+import Sidebar from '../partials/Sidebar';
+
+function SearchPage() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [userId, setUserId] = useState('');
+  const [name, setName] = useState('');
+  const [classValue, setClassValue] = useState('');
+  const [gender, setGender] = useState('');
+  const [results, setResults] = useState([]);
+
+  const handleSearch = async () => {
+    try {
+      const res = await axios.post('http://localhost:3008/search', {
+        userId,
+        name,
+        classValue,
+        gender,
+      });
+      setResults(res.data);
+    } catch (err) {
+      console.error('Search error:', err);
+    }
+  };
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-gradient-to-br from-indigo-100 via-blue-50 to-pink-100">
+      <Sidebar sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+      <div className="relative flex flex-col flex-1 overflow-y-auto">
+        <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+        <main className="p-6 space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <input value={userId} onChange={e => setUserId(e.target.value)} placeholder="User ID" className="input input-bordered" />
+            <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" className="input input-bordered" />
+            <input value={classValue} onChange={e => setClassValue(e.target.value)} placeholder="Class" className="input input-bordered" />
+            <input value={gender} onChange={e => setGender(e.target.value)} placeholder="Gender" className="input input-bordered" />
+          </div>
+          <button className="btn btn-primary" onClick={handleSearch}>Search</button>
+          {results.length > 0 && (
+            <table className="min-w-full text-sm table-auto bg-white rounded-md">
+              <thead className="bg-gray-100">
+                <tr>
+                  <th className="px-4 py-2">ID</th>
+                  <th className="px-4 py-2">Name</th>
+                  <th className="px-4 py-2">Class</th>
+                  <th className="px-4 py-2">Gender</th>
+                  <th className="px-4 py-2">Image</th>
+                </tr>
+              </thead>
+              <tbody>
+                {results.map(r => (
+                  <tr key={r.user_id} className="border-t">
+                    <td className="px-4 py-2">{r.user_id}</td>
+                    <td className="px-4 py-2">{r.name}</td>
+                    <td className="px-4 py-2">{r.class}</td>
+                    <td className="px-4 py-2">{r.gender}</td>
+                    <td className="px-4 py-2">{r.image && <img src={`data:image/jpeg;base64,${r.image}`} alt="user" className="w-16 h-16 object-cover" />}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export default SearchPage;

--- a/src/partials/Sidebar.jsx
+++ b/src/partials/Sidebar.jsx
@@ -750,7 +750,7 @@ function Sidebar({
               <li className={` hidden pl-4 pr-3 py-2 rounded-lg mb-0.5 last:mb-0 bg-linear-to-r ${pathname.includes("messages") && "from-violet-500/[0.12] dark:from-violet-500/[0.24] to-violet-500/[0.04]"}`}>
                 <NavLink
                   end
-                  to="/dashboard"
+                  to="/inbox"
                   className={`block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
                     pathname.includes("messages") ? "" : "hover:text-gray-900 dark:hover:text-white"
                   }`}
@@ -807,6 +807,23 @@ function Sidebar({
                     <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">
                       Calendar
                     </span>
+                  </div>
+                </NavLink>
+              </li>
+              {/* Search */}
+              <li className={`pl-4 pr-3 py-2 rounded-lg mb-0.5 last:mb-0 bg-linear-to-r ${pathname.includes("search") && "from-violet-500/[0.12] dark:from-violet-500/[0.24] to-violet-500/[0.04]"}`}>
+                <NavLink
+                  end
+                  to="/search"
+                  className={`block text-gray-800 dark:text-gray-100 truncate transition duration-150 ${
+                    pathname.includes("search") ? "" : "hover:text-gray-900 dark:hover:text-white"
+                  }`}
+                >
+                  <div className="flex items-center">
+                    <svg className={`shrink-0 fill-current ${pathname.includes('search') ? 'text-violet-500' : 'text-gray-400 dark:text-gray-500'}`} xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                      <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85Zm-5.242 1.656a5 5 0 1 1 0-10 5 5 0 0 1 0 10Z" />
+                    </svg>
+                    <span className="text-sm font-medium ml-4 lg:opacity-0 lg:sidebar-expanded:opacity-100 2xl:opacity-100 duration-200">Search</span>
                   </div>
                 </NavLink>
               </li>


### PR DESCRIPTION
## Summary
- create backend server for search API
- add inbox and search pages
- register calendar, inbox, and search routes
- update sidebar with links to new pages
- ignore node_modules and build output

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_685efa4b6164832d8be03a9bbe19f305